### PR TITLE
Added plugin-transform-runtime to deal with regeneratorRuntime issue 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,7 @@
     }
   },
   "plugins": [
-    ["styled-components", { "ssr": true, "displayName": true, "preprocess": false } ]
+    ["styled-components", { "ssr": true, "displayName": true, "preprocess": false } ],
+    ["@babel/plugin-transform-runtime"]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest --coverage"
   },
   "dependencies": {
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@testing-library/react": "9.4.0",
     "axios": "^0.19.2",
     "babel-plugin-styled-components": "^1.10.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -750,6 +750,16 @@
     resolve "^1.8.1"
     semver "^5.5.1"
 
+"@babel/plugin-transform-runtime@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz#c0153bc0a5375ebc1f1591cb7eea223adea9f169"
+  integrity sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.8.3"
+    "@babel/helper-plugin-utils" "^7.8.3"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0", "@babel/plugin-transform-shorthand-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz#28545216e023a832d4d3a1185ed492bcfeac08c8"


### PR DESCRIPTION
- Build causing `ReferenceError: regeneratorRuntime is not defined` 
- Added `@babel/plugin-transform-runtime` to fix this